### PR TITLE
Change Default UID to 501

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 ARG ARCH=
-ARG DIST=v3.15
+ARG DIST=v3.17
 FROM asymworks/multiarch-alpine:${ARCH}-${DIST}
 
-ARG DIST=v3.15
+ARG DIST=v3.17
 
 ENV RSA_PRIVATE_KEY_NAME packages@asymworks.com-5ff0a833.rsa
 ENV PACKAGER_PRIVKEY /home/builder/${RSA_PRIVATE_KEY_NAME}
 ENV REPODEST /packages
 
 RUN apk --no-cache add alpine-sdk coreutils cmake sudo \
-  && adduser -G abuild -g "Alpine Package Builder" -s /bin/ash -D builder \
+  && adduser -u 501 -G abuild -g "Alpine Package Builder" -s /bin/ash -D builder \
   && echo "builder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
   && mkdir /packages \
   && chown builder:abuild /packages \

--- a/abuilder
+++ b/abuilder
@@ -10,10 +10,8 @@ main() {
     export PACKAGER_PRIVKEY="/home/builder/.abuild/$RSA_PRIVATE_KEY_NAME"
   }
   ln -s /etc/apk/keys/${RSA_PRIVATE_KEY_NAME}.pub /home/builder/.abuild/${RSA_PRIVATE_KEY_NAME}.pub
-  sudo chown -R builder:abuild /home/builder/main/package
-  sudo chown -R builder:abuild $REPODEST
 
-  exec abuild "$@"
+  exec abuild -v "$@"
 }
 
 main "$@"


### PR DESCRIPTION
Changes the UID of the `builder` user to 501 so that MacOS/colima can mount the directory with a minimum of fuss.